### PR TITLE
Include devpi-lockdown

### DIFF
--- a/devpi-requirements.txt
+++ b/devpi-requirements.txt
@@ -13,6 +13,7 @@ devpi-ldap
 
 # Web extensions
 devpi-findlinks
+devpi-lockdown
 
 # Tools
 devpi-cleaner


### PR DESCRIPTION
Devpi lockdown may be desirable for private repositories, so this plugin should be included in the image.